### PR TITLE
add yt_dlp option to get video info if in doubt

### DIFF
--- a/app/src/main/python/YoutubeVideoDownloader.py
+++ b/app/src/main/python/YoutubeVideoDownloader.py
@@ -63,6 +63,7 @@ def getInfo(url: str, callback):
         'default-search': 'ytsearch',
         'youtube_include_dash_manifest': False,
         'youtube_include_hls_manifest': False,
+        'noplaylist': True,
     }
 
     with yt_dlp.YoutubeDL(ydl_opts) as ydl:


### PR DESCRIPTION
Changed yt_dlp setting to download only the single video info if the link is to a video. Previously if a link was given to a video in a playlist it would get the whole playlist.