### PR TITLE
Change list key to video id

### DIFF
--- a/app/src/main/java/com/tiesiogdvd/composetest/ui/ytDownload/YtDownloadViewModel.kt
+++ b/app/src/main/java/com/tiesiogdvd/composetest/ui/ytDownload/YtDownloadViewModel.kt
@@ -76,9 +76,11 @@ class YtDownloadViewModel @Inject constructor(
 
     fun loadSongsFromLink(){
         println(input.value)
-        toggleLoading(true)
-        if(input.value.isNotEmpty()){
+        if(input.value.isNotEmpty() and input.value.isNotBlank()){
+            toggleLoading(true)
+
             input.value = input.value.replace("\\s".toRegex(), "")
+
             viewModelScope.launch {
                 getSongInfo(input.value)
             }

--- a/app/src/main/java/com/tiesiogdvd/composetest/ui/ytDownload/YtDownloadViewModel.kt
+++ b/app/src/main/java/com/tiesiogdvd/composetest/ui/ytDownload/YtDownloadViewModel.kt
@@ -164,7 +164,9 @@ class YtDownloadViewModel @Inject constructor(
             } else {
                 // info is a single video
                 addVideoToList("", infoMap)
+                entriesNo = 1;
             }
+
             if(entriesNo!=0){
                 if(!isSelectionBarVisible.value){
                     toggleSelectionBar(true)

--- a/app/src/main/python/YoutubeVideoDownloader.py
+++ b/app/src/main/python/YoutubeVideoDownloader.py
@@ -69,17 +69,16 @@ def getInfo(url: str, callback):
         try:
             # Try to extract info from the original URL
             info = ydl.extract_info(url)
-            callback(info)
 
         except yt_dlp.utils.DownloadError:
             # Case where URL is not valid
             print("Invalid URL")
             # Searching for the query instead
             info = ydl.extract_info(f'ytsearch10:{url}')
-            callback(info)
 
-    #printListableKeysRecursive(info)
-    #callback(info)
+        callback(info)
+
+    # printListableKeysRecursive(info)
 
 
 listableTypes = [dict, list]


### PR DESCRIPTION
As mentioned in #7, changed video list id to youtube video id, which is unique and the video can be identified by it. This is mainly for the youtube search functionality, as it would be less reliable to update the ui if the index cannot identify the specific video. It would still be possible but other changes in the future may break it.